### PR TITLE
Update module config

### DIFF
--- a/create-genesis.go
+++ b/create-genesis.go
@@ -250,7 +250,8 @@ func invokeConstructorOrPanic(genesis *core.Genesis, systemContract common.Addre
 	} else {
 		bytecode = createProxyBytecodeWithConstructor(rawArtifact, typeNames, params)
 	}
-	result, _, err := virtualMachine.CreateWithAddress(vm.AccountRef(common.Address{}), bytecode, 10_000_000, big.NewInt(0), systemContract)
+	var zeroAddr = common.Address{}
+	result, _, err := virtualMachine.CreateWithAddress(zeroAddr, bytecode, 10_000_000, big.NewInt(0), systemContract)
 	if err != nil {
 		traceCallError(result)
 		panic(err)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/gorilla/mux v1.8.0 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.10.17 => github.com/ankr-network/bas-template-bsc v0.0.0-20220404131216-e5ac3a4a037a
+replace github.com/ethereum/go-ethereum v1.10.17 => github.com/antimatter-dao/bas-template-bsc v0.0.0-20220805065822-2ccf548eff4b
 
 //replace github.com/ethereum/go-ethereum v1.10.17 => ../

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/antimatter-dao/bas-genesis-config
 
-go 1.16
+go 1.17
 
 require (
 	github.com/ethereum/go-ethereum v1.10.17

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/ankr-network/bas-template-bsc v0.0.0-20220404131216-e5ac3a4a037a h1:tF8qskU5Z6WJlmv6exY4u3LRBTC/DWXM3jMgRgOavTU=
 github.com/ankr-network/bas-template-bsc v0.0.0-20220404131216-e5ac3a4a037a/go.mod h1:+94+OkOanGaFb5RyEKA7PRwF+8cqlAivlKAXhb7kI90=
+github.com/antimatter-dao/bas-template-bsc v0.0.0-20220805065822-2ccf548eff4b h1:wgquwzj1z4uiOwy4Uy/gtX3T/jrpPINLBpIUniEuXEY=
+github.com/antimatter-dao/bas-template-bsc v0.0.0-20220805065822-2ccf548eff4b/go.mod h1:+94+OkOanGaFb5RyEKA7PRwF+8cqlAivlKAXhb7kI90=
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/aws/aws-sdk-go-v2 v1.4.0/go.mod h1:tI4KhsR5VkzlUa2DZAdwx7wCAYGwkZZ1H31PYrBFx1w=
 github.com/aws/aws-sdk-go-v2/config v1.1.7/go.mod h1:6GFyKv06rDCBCIOmWe9vLi7ofCkE7y8aqI6a3tFWNQ0=


### PR DESCRIPTION
## Description

The PR updates some go mod configuration.

* Upgrade go version to `1.17`.
* Change `ethereum/go-ethereum` module to `antimatter-dao/bas-template-bsc`, which forks from `ankr-network/bas-template-bsc` and makes some changes.
* Fix compile failure after switching repo.

## Test

* Manual test in generating genesis using `make create-genesis`.