### PR TITLE
Change deployer mappings to public access

### DIFF
--- a/contracts/DeployerProxy.sol
+++ b/contracts/DeployerProxy.sol
@@ -32,7 +32,7 @@ contract DeployerProxy is InjectorContextHolder, IDeployerProxy {
         address deployer;
     }
 
-    mapping(address => Deployer) private _contractDeployers;
+    mapping(address => Deployer) public _contractDeployers;
     mapping(address => SmartContract) private _smartContracts;
 
     constructor(


### PR DESCRIPTION
The PR would expose the deployer list to public access, which is more convenient for whitelist limiting contract creation in `evm` calling context.